### PR TITLE
Potential fix for code scanning alert no. 13: Incomplete URL scheme check

### DIFF
--- a/_includes/Footer.html
+++ b/_includes/Footer.html
@@ -437,7 +437,12 @@ window.addEventListener('beforeprint', function() {
     anchors.forEach(function(anchor) {
         var href = anchor.href;
         var rawHref = anchor.getAttribute('href');
-        if (rawHref.startsWith('javascript:') || rawHref.startsWith('#') || anchor.closest('.print-hidden')) {
+        var rawHrefLower = rawHref ? rawHref.toLowerCase() : '';
+        if (rawHrefLower.startsWith('javascript:') ||
+            rawHrefLower.startsWith('data:') ||
+            rawHrefLower.startsWith('vbscript:') ||
+            rawHrefLower.startsWith('#') ||
+            anchor.closest('.print-hidden')) {
             return;
         }
         if (!seenUrls.has(href)) {


### PR DESCRIPTION
Potential fix for [https://github.com/joshbeckman/notes/security/code-scanning/13](https://github.com/joshbeckman/notes/security/code-scanning/13)

In general, to fix this kind of issue, any place that rejects `javascript:` URLs for safety should be updated to also reject `data:` and `vbscript:` schemes, using a case-insensitive check on the raw URL text (or a normalized variant) before use.

Here, the most targeted fix is to extend the existing condition on line 440 inside `_includes/Footer.html`. The code already has `rawHref.startsWith('javascript:') || rawHref.startsWith('#') ...`. We should add additional `startsWith` checks for `'data:'` and `'vbscript:'`. Because `startsWith` is case-sensitive and attributes may contain uppercase scheme names, we should normalize `rawHref` to lowercase before doing the checks to avoid missing variants like `JavaScript:` or `JaVaScRiPt:`. The minimal, safe change is:

- Introduce a local `var rawHrefLower = rawHref.toLowerCase();` immediately after obtaining `rawHref`.
- Replace the current scheme/fragment check to use `rawHrefLower` and include `data:` and `vbscript:`.

No new imports or external libraries are needed; `String.prototype.toLowerCase` is standard. This preserves existing behavior while closing the gap flagged by CodeQL.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
