### PR TITLE
fix(ci): don't fail POSSE workflow on Strava import error

### DIFF
--- a/.github/workflows/posse.yml
+++ b/.github/workflows/posse.yml
@@ -209,6 +209,7 @@ jobs:
         run: git push
       - name: Import Strava
         id: import_strava
+        continue-on-error: true
         run: bundle exec utilities/pesos_strava
         env:
           MAPBOX_TOKEN: ${{ secrets.MAPBOX_TOKEN }}


### PR DESCRIPTION
## Problem

Every recent POSSE workflow run has been failing — but not in the POSSE (Mastodon/Bluesky) steps, which pass fine. The whole job aborts on the `Import Strava` step:

```
Strava::Errors::Fault: Forbidden (403)
  from utilities/pesos_strava:110:in 'import_recent_activities'
```

Because that step lacked `continue-on-error`, everything after it — `Import YouTube`, `Serialize`, `Optimize images`, **Build with Jekyll**, and **Deploy** — never ran. So the site also wasn't being rebuilt/deployed.

## Fix

Add `continue-on-error: true` to the Strava step, matching the other PESOS imports (`Import Mastodon`, `Import Bluesky`, `Import HackerNews`, `Import YouTube`) that already tolerate upstream failures.

## Follow-up (not in this PR)

The underlying 403 is a Strava auth issue — the `joshbeckman-stravaoauthclient` Val Town OAuth client is returning a stale/invalid access token (the refresh token has likely lost `activity:read` scope). Needs re-authorization to restore Strava imports.