### PR TITLE
Add internal links to “Slayyying Chest 🏋️”

### DIFF
--- a/exercise/weight-training/_posts/2026-07-03-19168376992.md
+++ b/exercise/weight-training/_posts/2026-07-03-19168376992.md
@@ -34,6 +34,6 @@ serial_number: 2026.ECE.111
 ---
 ![Slayyying Chest](/assets/images/u9g--xvywLQ33QeXuia2cZo1RTIp5xHKLWmIGgaBp-8-727x2048.jpg.jpeg)
 
-Bopping around an empty holiday gym with Slayyyter in my ears felt good, even if my less frequent gym visits have made these lifts harder.
+Bopping around an empty holiday gym with [Slayyyter](/blog/listening/record-club-slayyyter-wor-t-girl-in-america) in my ears felt good, even if my less frequent gym visits have made these lifts harder.
 
 Unknown location (probably inside)


### PR DESCRIPTION
Suggested by criticCron while critiquing [Slayyying Chest 🏋️](https://www.joshbeckman.org/exercise/weight-training/19168376992).

- Link **Slayyyter in my ears** → [WOR$T GIRL IN AMERICA by Slayyyter](https://www.joshbeckman.org/blog/listening/record-club-slayyyter-wor-t-girl-in-america) — The post names the artist Slayyyter by name, and the garden has a dedicated review of that album — linking the name connects the workout log to the music that was playing.

Opened as a draft — review and mark ready to merge, or close.

Generated-by: AI (criticCron/Anthropic/claude-sonnet-4-6)