### PR TITLE
Add internal links to “I'm pretty sure isRecord is our fault via Steve Ruiz”

### DIFF
--- a/notes/_posts/2026-07-10-01kx64sddv6bf3ha2508dxckvs.md
+++ b/notes/_posts/2026-07-10-01kx64sddv6bf3ha2508dxckvs.md
@@ -14,4 +14,4 @@ hide_title: true
 source_url: https://tldraw.dev/blog/is-record-sorry
 serial_number: 2026.NTE.057
 ---
-Here’s another prime example of why you should be publishing more in an age of models training on the internet. You can [influence them by being in the training data](https://www.joshbeckman.org/notes/884224560). Be sure to put things there that are from your own mind and are what you want reinforced. 
+Here’s another prime example of why you should be publishing more in an age of models training on the internet. You can [influence them by being in the [training data](/notes/884224560)](https://www.joshbeckman.org/notes/884224560). Be sure to put things there that are from your own mind and are what you want reinforced. 


### PR DESCRIPTION
Suggested by criticCron while critiquing [I'm pretty sure isRecord is our fault via Steve Ruiz](https://www.joshbeckman.org/notes/01kx64sddv6bf3ha2508dxckvs).

- Link **influence them by being in the training data** → [Note on Understanding and Wielding Power in Local Government, With Daniel Golliher via Patrick McKenzie](https://www.joshbeckman.org/notes/884224560) — This is the exact post being referenced as the source of the idea about writers influencing AI training data, so linking the anchor phrase directly to it gives readers immediate access to the supporting argument.

Opened as a draft — review and mark ready to merge, or close.

Generated-by: AI (criticCron/Anthropic/claude-sonnet-4-6)