### PR TITLE
fix(webmentions): isolate per-target failures from unparseable Link headers

### DIFF
--- a/utilities/send_mentions_from_rss.rb
+++ b/utilities/send_mentions_from_rss.rb
@@ -28,19 +28,35 @@ class SendMentionsFromRss
     doc = Nokogiri::XML(export_res.body)
     doc.css(config.item_selector).each do |link|
       href = config.item_href_proc.call(link)
-      Webmention.mentioned_urls(href).each do |url|
+      mentioned_urls_for(href).each do |url|
         if url.match?(config.excluded_url_matcher)
           puts "skipping #{url}" if config.verbose
           next
         end
 
-        result = Webmention.send_webmention(href, url)
-        if result.ok?
-          puts "Sent mention of #{url} by #{href}"
-        else
-          puts result.message
-        end
+        send_webmention(href, url)
       end
     end
+  end
+
+  # Isolate failures to a single source/target so one unparseable response
+  # (e.g. a Shopify `Link` header whose `imagesrcset` contains commas, which
+  # crashes link-header-parser) cannot abort the entire run.
+  def self.mentioned_urls_for(href)
+    Webmention.mentioned_urls(href)
+  rescue StandardError => e
+    warn "Failed to extract mentioned URLs from #{href}: #{e.class}: #{e.message}"
+    []
+  end
+
+  def self.send_webmention(href, url)
+    result = Webmention.send_webmention(href, url)
+    if result.ok?
+      puts "Sent mention of #{url} by #{href}"
+    else
+      puts result.message
+    end
+  rescue StandardError => e
+    warn "Failed to send webmention of #{url} by #{href}: #{e.class}: #{e.message}"
   end
 end


### PR DESCRIPTION
## Problem

The scheduled `webmentions.yml` job has failed on every run since 2026-07-12, immediately after publishing the [roast-notes-colombia-inga-red-honey](https://www.joshbeckman.org/blog/roast-notes-colombia-inga-red-honey-by-la-colombe) post. That post links to a La Colombe product page — a Shopify store that emits a `Link` HTTP header with `imagesrcset` attribute values containing commas.

`link-header-parser` splits the `Link` header on commas, so the `imagesrcset` fragments become segments that don't match its `<url>; params` regex. `match_data` comes back `nil`, and `match_data[:target_string]` raises `NoMethodError: undefined method '[]' for nil`. Endpoint discovery for that one target aborted the entire run.

This is external content, not a dependency change — `Gemfile.lock` hasn't moved since 2026-07-08.

## Fix

Isolate per-source and per-target failures so a single unparseable external response is logged and skipped rather than killing the whole job. Verified locally: the run now exits 0 and logs the La Colombe target as a skipped failure.

## Trade-off

This makes the job resilient but does not make that specific webmention deliverable. It won't send while La Colombe emits the comma-bearing header. Resilience is the durable choice since the next such `Link` header would otherwise hit the same crash.

Generated-by: AI (pi/anthropic/claude-opus-4)
