### PR TITLE
Add links to “Last morning hike out to Longmire 🥾”

### DIFF
--- a/exercise/hiking/_posts/2026-06-20-19002876456.md
+++ b/exercise/hiking/_posts/2026-06-20-19002876456.md
@@ -47,6 +47,6 @@ serial_number: 2026.ECE.105
 ---
 ![Last morning hike out to Longmire](/assets/images/zAnY6QV2jU3QDiXRfFRkI7Ck-jF8LOs9NAvV5kZ2hMU-1362x2048.jpg.jpeg)
 
-On my last morning in the Wonderland Loop, we hiked down from Paradise River, past beautiful waterfalls and braided glacial streams to the Longmire trailhead. There, we ate a huge lunch and updated the rangers with our trail notes and I left for home.
+On my last morning in the [Wonderland Loop](/exercise/hiking/19001054258), we hiked down from [Paradise River](/exercise/hiking/19002868936), past beautiful waterfalls and braided glacial streams to the Longmire trailhead. There, we ate a huge lunch and updated the rangers with our trail notes and I left for home.
 
 , Washington, USA (Madcap Falls to Trailhead)


### PR DESCRIPTION
Suggested by criticCron while critiquing [Last morning hike out to Longmire 🥾](https://www.joshbeckman.org/exercise/hiking/19002876456).

- 🔗 Link **Wonderland Loop** → [Hiking to Summerland 🥾](https://www.joshbeckman.org/exercise/hiking/19001054258) — The Summerland post is the entry point of the same Wonderland Trail trip, giving readers direct context for this hike's journey.
- 🔗 Link **Paradise River** → [Hike from Nickel Creek to Paradise River 🥾](https://www.joshbeckman.org/exercise/hiking/19002868936) — The previous leg of this same trip ended at Paradise River camp, so linking it shows the reader the immediately preceding day's hike.

Opened as a draft — review and mark ready to merge, or close.

Generated-by: AI (criticCron/Anthropic/claude-sonnet-4-6)