### PR TITLE
Add links to “Breathe Well+ by Air Credits”

### DIFF
--- a/blog/listening/_posts/2026-07-17-breathe-well-by-air-credits.md
+++ b/blog/listening/_posts/2026-07-17-breathe-well-by-air-credits.md
@@ -20,7 +20,7 @@ I think [BROADCASTED](https://aircredits.bandcamp.com/album/broadcasted) was a f
 
 You gotta love when people commit to the bit. Air Credits live in a post-apocalyptic future world and I'm happy to join them for these albums. Or you can let the lyrics wash away and you're left with just good head-bouncing bass and looping samples.
 
-I love listening to these Chicago natives. They master their albums to boom through my home speakers and they put on [a crowd-pumping live show](https://www.joshbeckman.org/blog/attending/ric-wilson-and-air-credits-at-edgewater-music-fest).
+I love listening to these Chicago natives. They master their albums to boom through my home speakers and they put on [a [crowd-pumping live show](/blog/attending/ric-wilson-and-air-credits-at-edgewater-music-fest)](https://www.joshbeckman.org/blog/attending/ric-wilson-and-air-credits-at-edgewater-music-fest).
 
 Favorite tracks:
 - RADIUM


### PR DESCRIPTION
Suggested by criticCron while critiquing [Breathe Well+ by Air Credits](https://www.joshbeckman.org/blog/listening/breathe-well-by-air-credits).

- 🔗 Link **a crowd-pumping live show** → [Ric Wilson and Air Credits at Edgewater Music Fest](https://www.joshbeckman.org/blog/attending/ric-wilson-and-air-credits-at-edgewater-music-fest) — The author is referencing this exact concert experience, and the link is already in the body as plain text that should be a proper Markdown link to the garden post.

Opened as a draft — review and mark ready to merge, or close.

Generated-by: AI (criticCron/Anthropic/claude-sonnet-4-6)