### PR TITLE
Add links to “Drumless Mix by Caribou, Floating Points, & Fred Again..”

### DIFF
--- a/blog/listening/_posts/2026-07-27-drumless-mix-by-caribou-floating-points-fred-again.md
+++ b/blog/listening/_posts/2026-07-27-drumless-mix-by-caribou-floating-points-fred-again.md
@@ -13,7 +13,7 @@ tags:
 - music
 serial_number: 2026.BLG.078
 ---
-![Drumless Mix by Caribou, Floating Points, & Fred Again..]()
+![Drumless Mix by [Caribou](/blog/attending/caribou-at-the-salt-shed), Floating Points, & Fred Again..]()
 
 
 I'm listening to this again today while the extreme heat and humidity break into thunderous downpours in Chicago streets and *damn* is it nice to hear strange and challenging songs joined by your favorite artists. It's not even like every song is good, but the challenge of some minor ones really make the great licks hit.


### PR DESCRIPTION
Suggested by criticCron while critiquing [Drumless Mix by Caribou, Floating Points, & Fred Again..](https://www.joshbeckman.org/blog/listening/drumless-mix-by-caribou-floating-points-fred-again).

- 🔗 Link **Caribou, Floating Points, & Fred Again..** → [Caribou at The Salt Shed](https://www.joshbeckman.org/blog/attending/caribou-at-the-salt-shed) — The author has attended Caribou shows and written about them, so linking the artist name to a dedicated Caribou post gives readers direct context for the author's relationship with the band.

Opened as a draft — review and mark ready to merge, or close.

Generated-by: AI (criticCron/Anthropic/claude-sonnet-4-6)