### PR TITLE
Add links to “Lifestyle by Dux Content”

### DIFF
--- a/blog/listening/_posts/2026-07-28-record-club-dux-content-lifestyle-2.md
+++ b/blog/listening/_posts/2026-07-28-record-club-dux-content-lifestyle-2.md
@@ -19,6 +19,6 @@ serial_number: 2026.BLG.079
 ---
 ![Lifestyle by Dux Content](https://cdn.rcrd.club/releases/mv6nknr3p20lqxod.jpg)
 
-<p>I found this today and played it on a whim. What a jarring surprise! Originally from 2012, I can hear so much of what True Cuckoo and Disasterpeace and even 100 Gecs would pick up in the next decade.</p><p>The initial half is the most distinct but also the most jarring to my ears. The latter half calms down and escorts you out the irreverent playhouse of musical clash safely.</p>
+<p>I found this today and played it on a whim. What a jarring surprise! Originally from 2012, I can hear so much of what [True Cuckoo](https://www.cuckoo.no/) and [Disasterpeace](https://disasterpeace.com/) and even 100 Gecs would pick up in the next decade.</p><p>The initial half is the most distinct but also the most jarring to my ears. The latter half calms down and escorts you out the irreverent playhouse of musical clash safely.</p>
 
 {{ "https://music.apple.com/us/album/lifestyle/6776669363" | itunesify }}


### PR DESCRIPTION
Suggested by criticCron while critiquing [Lifestyle by Dux Content](https://www.joshbeckman.org/blog/listening/record-club-dux-content-lifestyle-2).

- 🌐 Link **Disasterpeace** → [Disasterpeace – Official Website](https://disasterpeace.com/) — Links to the official site of composer Rich Vreeland (Disasterpeace), known for chiptune work and film scores like Fez and It Follows.
- 🌐 Link **True Cuckoo** → [True Cuckoo – Official Website](https://www.cuckoo.no/) — Links the reader directly to True Cuckoo's official site so they can explore the Norwegian synth artist's music and videos.

Opened as a draft — review and mark ready to merge, or close.

Generated-by: AI (criticCron/Anthropic/claude-sonnet-4-6)